### PR TITLE
Column ordering queryset passthrough

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -239,6 +239,18 @@ class Column(object):
         """
         return value
 
+    def order(self, queryset, is_descending):
+        """
+        Returns the queryset of the table.
+
+        This method can be overridden by :ref:`table.order_FOO` methods on the
+        table or by subclassing `.Column`. Only overrides if second element
+        in return tuple is True.
+
+        :returns: Tuple (queryset, boolean)
+        """
+        return (queryset, False)
+
     @classmethod
     def from_field(cls, field):
         """
@@ -527,6 +539,7 @@ class BoundColumns(object):
         for name, column in six.iteritems(table.base_columns):
             self.columns[name] = bc = BoundColumn(table, column, name)
             bc.render = getattr(table, 'render_' + name, column.render)
+            bc.order = getattr(table, 'order_' + name, column.order)
 
     def iternames(self):
         return (name for name, column in self.iteritems())

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -102,6 +102,12 @@ class TableData(object):
             else:
                 accessors += bound_column.order_by
         if hasattr(self, 'queryset'):
+            # Custom ordering
+            if bound_column:
+                self.queryset, custom = bound_column.order(self.queryset, alias[0] == '-')
+                if custom:
+                    return
+            # Traditional ordering
             translate = lambda accessor: accessor.replace(Accessor.SEPARATOR, QUERYSET_ACCESSOR_SEPARATOR)
             if accessors:
                 self.queryset = self.queryset.order_by(*(translate(a) for a in accessors))


### PR DESCRIPTION
Queryset passes through function to be tinkered with when a column is
sorted.

Similar to `render_FOO`

Example Usage:

``` python
def order_success_rate(self, queryset, is_descending):
    # Custom queryset ordering that uses the database to calculate the
    # success rate of a webpage game
    queryset = queryset.extra(
        select={'value': '(clicks / completed) * 100'},
        order_by=(('-' if is_descending else '') + 'value',)
    )

    # Tuple of reordered queryset and a boolean marking as reordered so
it will
    # override the order of the column
    return (queryset, True)
```
